### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
     :target: https://travis-ci.org/ojii/gettext.js
 
 .. image:: https://readthedocs.org/projects/gettextjs/badge/?version=latest
-    :target: http://gettextjs.readthedocs.org/en/latest/?badge=latest
+    :target: https://gettextjs.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
 gettext.js
@@ -14,7 +14,7 @@ directly from Javascript in your browser.
 
 Demo: https://cdn.rawgit.com/ojii/gettext.js/master/demo/index.html
 
-Docs: http://gettextjs.readthedocs.org/
+Docs: https://gettextjs.readthedocs.io/
 
 Usage
 =====


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
